### PR TITLE
Restore unused code elements

### DIFF
--- a/scrape_dockets.py
+++ b/scrape_dockets.py
@@ -1,5 +1,7 @@
 import os
-from urllib.parse import urljoin
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse, parse_qs
 import time
 import logging
 import random
@@ -191,6 +193,8 @@ def download_pdf(driver, pdf_info, directory):
     """Downloads a single PDF from the given pdf_info to the specified directory."""
     pdf_url = pdf_info['url']
     filename_suggestion_base = pdf_info.get('filename_suggestion', 'untitled_document')
+    original_href = pdf_info.get('original_href')
+    filename = None
 
     try:
         logger.info(f"Attempting to navigate to PDF URL via Selenium: {pdf_url}")


### PR DESCRIPTION
## Summary
- restore requests and BeautifulSoup imports
- bring back unused variables `original_href` and `filename`

## Testing
- `python -m py_compile scrape_dockets.py`
- `pyflakes scrape_dockets.py` *(fails: imported but unused / assigned but unused)*

------
https://chatgpt.com/codex/tasks/task_e_684cecd0f83c832ca4ae6ab0c58cfe21